### PR TITLE
Add slow computer

### DIFF
--- a/lib/computer_player.ex
+++ b/lib/computer_player.ex
@@ -3,7 +3,7 @@ defmodule TicTacToe.ComputerPlayer do
   defstruct name: "Computer", marker: "o", score: 0
 
   def build(name, marker) do
-    %TicTacToe.HumanPlayer{name: name, marker: marker}
+    %TicTacToe.ComputerPlayer{name: name, marker: marker}
   end
 
   def computer_move(current_board, {player_1, player_2}) do
@@ -11,8 +11,8 @@ defmodule TicTacToe.ComputerPlayer do
     TicTacToe.Minimax.best_move(current_board, {player_1, player_2})
   end
 
-  def update_score(name, marker, updated_score) do
-    %TicTacToe.HumanPlayer{name: name, marker: marker, score: updated_score}
+  def update_score(player) do
+    %TicTacToe.ComputerPlayer{name: player.name, marker: player.marker, score: player.score + 1}
   end
 
 end

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -143,7 +143,7 @@ defmodule TicTacToe.Game do
     if winning_player.name =~ "Computer" do
       ComputerPlayer.update_score(winning_player)
     else
-      HumanPlayer.update_score(winning_player.name, winning_player.marker, winning_player.score + 1)
+      HumanPlayer.update_score(winning_player)
     end
   end
 

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -1,5 +1,5 @@
 defmodule TicTacToe.Game do
-  alias TicTacToe.{Board, HumanPlayer, ComputerPlayer, Validator, CliDisplay, Messager}
+  alias TicTacToe.{Board, HumanPlayer, SlowComputerPlayer, ComputerPlayer, Validator, CliDisplay, Messager}
 
   def play_tic_tac_toe do
     welcome_players
@@ -48,8 +48,8 @@ defmodule TicTacToe.Game do
   end
 
   def build_computer_computer_game do
-    player_1 = ComputerPlayer.build("Computer 1", "\e[36mx\e[0m")
-    player_2 = ComputerPlayer.build("Computer 2", "\e[33mo\e[0m")
+    player_1 = SlowComputerPlayer.build("Computer 1", "\e[36mx\e[0m")
+    player_2 = SlowComputerPlayer.build("Computer 2", "\e[33mo\e[0m")
     {player_1, player_2}
   end
 
@@ -105,18 +105,29 @@ defmodule TicTacToe.Game do
 
   defp mark_board(current_board, {player_1, player_2}) do
     display_board(current_board)
-    if player_1.name =~ "Computer" do
-      Messager.turn_input_request(player_1.name, player_1.marker)
-      |> CliDisplay.write
-      computer_mark_cell(current_board, {player_1, player_2})
-    else
-      human_choose_cell(player_1)
-      |> mark_cell_if_available(current_board, {player_1, player_2})
-    end
+    cond do
+      player_1.name == "Computer" ->
+        Messager.turn_input_request(player_1.name, player_1.marker)
+        |> CliDisplay.write
+        computer_mark_cell(current_board, {player_1, player_2})
+      player_1.name =~ "Computer" ->
+        Messager.turn_input_request(player_1.name, player_1.marker)
+        |> CliDisplay.write
+        slow_computer_mark_cell(current_board, {player_1, player_2})
+      :else ->
+        human_choose_cell(player_1)
+        |> mark_cell_if_available(current_board, {player_1, player_2})
+      end
   end
 
   def computer_mark_cell(current_board, {player_1, player_2}) do
     ComputerPlayer.move(current_board, {player_1, player_2})
+    |> Board.mark_cell(player_1.marker, current_board)
+    |> take_turn({player_2, player_1})
+  end
+
+  def slow_computer_mark_cell(current_board, {player_1, player_2}) do
+    SlowComputerPlayer.move(current_board, {player_1, player_2})
     |> Board.mark_cell(player_1.marker, current_board)
     |> take_turn({player_2, player_1})
   end

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -116,7 +116,7 @@ defmodule TicTacToe.Game do
   end
 
   def computer_mark_cell(current_board, {player_1, player_2}) do
-    ComputerPlayer.computer_move(current_board, {player_1, player_2})
+    ComputerPlayer.move(current_board, {player_1, player_2})
     |> Board.mark_cell(player_1.marker, current_board)
     |> take_turn({player_2, player_1})
   end

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -141,7 +141,7 @@ defmodule TicTacToe.Game do
 
   def award_point(winning_player) do
     if winning_player.name =~ "Computer" do
-      ComputerPlayer.update_score(winning_player.name, winning_player.marker, winning_player.score + 1)
+      ComputerPlayer.update_score(winning_player)
     else
       HumanPlayer.update_score(winning_player.name, winning_player.marker, winning_player.score + 1)
     end

--- a/lib/human_player.ex
+++ b/lib/human_player.ex
@@ -6,8 +6,8 @@ defmodule TicTacToe.HumanPlayer do
     %TicTacToe.HumanPlayer{name: String.capitalize(name), marker: marker}
   end
 
-  def update_score(name, marker, updated_score) do
-    %TicTacToe.HumanPlayer{name: name, marker: marker, score: updated_score}
+  def update_score(player) do
+    %TicTacToe.HumanPlayer{name: player.name, marker: player.marker, score: player.score + 1}
   end
 
 end

--- a/lib/slow_computer_player.ex
+++ b/lib/slow_computer_player.ex
@@ -1,18 +1,18 @@
-defmodule TicTacToe.ComputerPlayer do
+defmodule TicTacToe.SlowComputerPlayer do
 
   defstruct name: "Computer", marker: "o", score: 0
 
   def build(name, marker) do
-    %TicTacToe.ComputerPlayer{name: name, marker: marker}
+    %TicTacToe.SlowComputerPlayer{name: name, marker: marker}
   end
 
   def move(current_board, {player_1, player_2}) do
+    :timer.sleep(1000)
     TicTacToe.Minimax.best_move(current_board, {player_1, player_2})
   end
 
   def update_score(player) do
-    %TicTacToe.ComputerPlayer{name: player.name, marker: player.marker, score: player.score + 1}
+    %TicTacToe.SlowComputerPlayer{name: player.name, marker: player.marker, score: player.score + 1}
   end
 
 end
-

--- a/test/computer_player_test.exs
+++ b/test/computer_player_test.exs
@@ -7,4 +7,8 @@ defmodule TicTacToeTest.ComputerPlayer do
     assert new_player.marker == "o"
   end
 
+  test "computer player updates score" do
+    computer_player = TicTacToe.ComputerPlayer.build("Computer", "x")
+    assert TicTacToe.ComputerPlayer.update_score(computer_player) == %TicTacToe.ComputerPlayer{marker: "x", name: "Computer", score: 1}
+  end
 end

--- a/test/computer_player_test.exs
+++ b/test/computer_player_test.exs
@@ -7,8 +7,16 @@ defmodule TicTacToeTest.ComputerPlayer do
     assert new_player.marker == "o"
   end
 
+  test "builds new player" do
+    new_player = TicTacToe.ComputerPlayer.build("Computer", "o")
+    assert new_player.name == "Computer"
+    assert new_player.marker == "o"
+    assert new_player.score == 0
+  end
+
   test "computer player updates score" do
     computer_player = TicTacToe.ComputerPlayer.build("Computer", "x")
     assert TicTacToe.ComputerPlayer.update_score(computer_player) == %TicTacToe.ComputerPlayer{marker: "x", name: "Computer", score: 1}
   end
+
 end

--- a/test/game_test.exs
+++ b/test/game_test.exs
@@ -55,12 +55,6 @@ defmodule TicTacToeTest.Game do
     end) =~ "Welcome to Tic Tac Toe"
   end
 
-  test "a computer vs computer game plays" do
-    assert capture_io("d\nI'm done", fn -> 
-      TicTacToe.Game.play_tic_tac_toe
-    end) =~ "Computer 1's turn"
-  end
-
   test "shows score when one game ends" do
     assert capture_io("a\nGary\nBarry\n1\n2\n5\n4\n9\nI'm done", fn ->
       TicTacToe.Game.play_tic_tac_toe

--- a/test/human_player_test.exs
+++ b/test/human_player_test.exs
@@ -13,4 +13,9 @@ defmodule TicTacToeTest.HumanPlayer do
     assert new_player.marker == "o"
   end
 
+  test "human player updates score" do
+    human_player = TicTacToe.ComputerPlayer.build("Daisy", "x")
+    assert TicTacToe.HumanPlayer.update_score(human_player) == %TicTacToe.HumanPlayer{marker: "x", name: "Daisy", score: 1}
+  end
+
 end

--- a/test/slow_computer_player_test.exs
+++ b/test/slow_computer_player_test.exs
@@ -1,0 +1,22 @@
+defmodule TicTacToeTest.SlowComputerPlayer do
+  use ExUnit.Case
+
+  test "computer player has a default name and marker" do
+    new_player = %TicTacToe.SlowComputerPlayer{}
+    assert new_player.name == "Computer"
+    assert new_player.marker == "o"
+  end
+
+  test "builds new player" do
+    new_player = TicTacToe.SlowComputerPlayer.build("Computer", "o")
+    assert new_player.name == "Computer"
+    assert new_player.marker == "o"
+    assert new_player.score == 0
+  end
+
+  test "computer player updates score" do
+    computer_player = TicTacToe.SlowComputerPlayer.build("Computer", "x")
+    assert TicTacToe.ComputerPlayer.update_score(computer_player) == %TicTacToe.ComputerPlayer{marker: "x", name: "Computer", score: 1}
+  end
+
+end


### PR DESCRIPTION
I separated the slow computer into its own module, where the erlang timer function creates a pause of 1 second before each computer turn.

I improved test this computer player separately, so that timer need only be tested once.

I created a separate function for the slow computer move in the game module, and added another condition to the move function to use this.

I wrote more tests and corrected tests that used the wrong module name for HumanPlayer and ComputerPlayer.

I added the SlowComputerPlayer alias to the Game module.

Overall I had to change 3 existing modules and create 1 new one.