### PR TITLE
Minimax

### DIFF
--- a/:w
+++ b/:w
@@ -12,19 +12,6 @@ defmodule TicTacToeTest.Minimax do
     assert TicTacToe.Minimax.best_move(current_board, "x") == "1"
   end
 
-  test "gives possible_boards" do
-    current_board = ["1", "o", "3"]
-    assert TicTacToe.Minimax.possible_boards(current_board, "x") == [["x", "o", "3"],["1", "o", "x"]]
-  end
-
-  test "returns values of board" do
-    current_board = ["1", "o", "3",
-                     "4", "x", "6",
-                     "o", "8", "x"]
-    possible_boards = TicTacToe.Minimax.possible_boards(current_board, "x")
-    assert TicTacToe.Minimax.values(possible_boards, current_board) == [{1, "1"}, {0, "3"}, {0, "4"}, {0, "6"}, {0, "8"}]
-  end
-
   test "returns best move when terminal due to win" do
     current_board =   ["x", "o", "3",
                       "4", "x", "6",
@@ -34,6 +21,14 @@ defmodule TicTacToeTest.Minimax do
                       "4", "x", "6",
                       "o", "8", "x"]
     assert TicTacToe.Minimax.best_move(current_board, "x") == "1"
+  end
+
+  test "returns values of board" do
+    current_board =   ["1", "o", "3",
+                      "4", "x", "6",
+                      "o", "8", "x"]
+    possible_boards = TicTacToe.Minimax.possible_boards(current_board, "x")
+    assert TicTacToe.Minimax.values(possible_boards, current_board) == [{0, "1"}, {0, "3"}, {0, "4"}, {0, "6"}, {0, "8"}]
   end
 
 end

--- a/lib/computer_player.ex
+++ b/lib/computer_player.ex
@@ -6,9 +6,9 @@ defmodule TicTacToe.ComputerPlayer do
     %TicTacToe.HumanPlayer{name: name, marker: marker}
   end
 
-  def computer_move(current_board, {player_1, player_2}) do
+  def computer_move(current_board, player_1) do
     :timer.sleep(1000)
-    TicTacToe.Minimax.best_move(current_board, {player_1, player_2})
+    TicTacToe.Minimax.best_move(current_board, player_1.marker)
   end
 
   def update_score(name, marker, updated_score) do

--- a/lib/game.ex
+++ b/lib/game.ex
@@ -30,26 +30,26 @@ defmodule TicTacToe.Game do
   end
 
   def build_human_human_game do
-    player_1 = build_human_player("Player 1", "\e[36mx\e[0m")
-    player_2 = build_human_player("Player 2", "\e[33mo\e[0m")
+    player_1 = build_human_player("Player 1", "x")
+    player_2 = build_human_player("Player 2", "o")
     {player_1, player_2}
   end
 
   def build_human_computer_game do
-    player_1 = build_human_player("Human", "\e[36mx\e[0m")
-    player_2 = ComputerPlayer.build("Computer", "\e[33mo\e[0m")
+    player_1 = build_human_player("Human", "x")
+    player_2 = ComputerPlayer.build("Computer", "o")
     {player_1, player_2}
   end
 
   def build_computer_human_game do
-    player_1 = ComputerPlayer.build("Computer", "\e[33mo\e[0m")
-    player_2 = build_human_player("Human", "\e[36mx\e[0m")
+    player_1 = ComputerPlayer.build("Computer", "o")
+    player_2 = build_human_player("Human", "x")
     {player_1, player_2}
   end
 
   def build_computer_computer_game do
-    player_1 = ComputerPlayer.build("Computer 1", "\e[36mx\e[0m")
-    player_2 = ComputerPlayer.build("Computer 2", "\e[33mo\e[0m")
+    player_1 = ComputerPlayer.build("Computer 1", "x")
+    player_2 = ComputerPlayer.build("Computer 2", "o")
     {player_1, player_2}
   end
 
@@ -116,7 +116,7 @@ defmodule TicTacToe.Game do
   end
 
   def computer_mark_cell(current_board, {player_1, player_2}) do
-    ComputerPlayer.computer_move(current_board, {player_1, player_2})
+    ComputerPlayer.computer_move(current_board, player_1)
     |> Board.mark_cell(player_1.marker, current_board)
     |> take_turn({player_2, player_1})
   end

--- a/lib/messager.ex
+++ b/lib/messager.ex
@@ -1,12 +1,41 @@
 defmodule TicTacToe.Messager do
 
   def format_board(current_board) do
-    Enum.chunk(current_board, 3)
+    Enum.chunk(colour_board(current_board), 3)
     |> Enum.map(fn(row) ->
       Enum.join(row, " ")
     end)
     |> Enum.join("\n")
     |> String.pad_leading(20, "\n")
+  end
+
+  def colour_board(current_board) do
+    Enum.map(current_board, fn(cell) ->
+      colour_marker(cell)
+    end)
+  end
+
+  def cyan do
+    IO.ANSI.cyan()
+  end
+
+  def yellow do
+    IO.ANSI.yellow()
+  end
+
+  def reset do
+    IO.ANSI.reset()
+  end
+
+  def colour_marker(marker) do
+    cond do
+      marker == "x" ->
+        "#{cyan}x#{reset}"
+      marker == "o" ->
+        "#{yellow}o#{reset}"
+      :else ->
+        marker
+      end
   end
 
   def welcome_introduction do
@@ -30,7 +59,7 @@ defmodule TicTacToe.Messager do
   end
 
   def turn_input_request(player_name, marker) do
-    "\nIt's #{player_name}'s turn with the marker #{marker}, \ninput the number of the position that you would like to mark: \n"
+    "\nIt's #{player_name}'s turn with the marker #{colour_marker(marker)}, \ninput the number of the position that you would like to mark: \n"
   end
 
   def unavailable_cell do

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -20,9 +20,9 @@ defmodule TicTacToe.Minimax do
   def find_values(current_board, max_player) do
     Enum.map(possible_moves(current_board, max_player), fn(possible_board) ->
       if TicTacToe.Board.win?(possible_board) do
-        {1, "1"}
+        {1, changed_cell(current_board, possible_board)} 
       else
-        {0, "3"}
+        {0, changed_cell(current_board, possible_board)} 
       end
     end)
     # for every available cell on the board return a new board with that cell marked, and determine whether a win for max_player or draw and return these tuples of minimax value and cell number in a list.
@@ -46,6 +46,13 @@ defmodule TicTacToe.Minimax do
 
   def ghost_mark(cell, marker, current_board) do
     List.replace_at(current_board, String.to_integer(cell) - 1, marker)
+  end
+
+  def changed_cell(current_board, marked_board) do
+    Enum.find(Enum.zip(current_board, marked_board), fn({x, y}) ->
+      x != y
+    end)
+  |> elem(0)
   end
     
 end

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -1,20 +1,28 @@
 defmodule TicTacToe.Minimax do
 
   def best_move(current_board, {max_player, min_player}) do
-    elem(minimax(current_board, [], {max_player, min_player}), 1)
+    elem(minimax(current_board, {max_player, min_player}), 1)
   end
 
-  def minimax(current_board, minimax_values, {max_player, min_player}) do
+  def minimax(current_board, {max_player, min_player}) do
     cond do
       terminal?(find_values(current_board, max_player)) ->
-        {0, "3"}
+        give_terminal_value(find_values(current_board, max_player))
     end
   end
 
   def terminal?(minimax_values) do
-    Enum.count(minimax_values) == 1 or Enum.any?(minimax_values, fn({value, cell_number}) ->
+    Enum.count(minimax_values) == 1 or Enum.any?(minimax_values, fn({value, _}) ->
       value == 1
     end)
+  end
+
+  def give_terminal_value(minimax_values) do
+    if Enum.count(minimax_values) == 1 do
+      Enum.at(minimax_values, 0)
+    else
+      Enum.max(minimax_values)
+    end
   end
 
   def find_values(current_board, max_player) do
@@ -25,7 +33,6 @@ defmodule TicTacToe.Minimax do
         {0, changed_cell(current_board, possible_board)} 
       end
     end)
-    # for every available cell on the board return a new board with that cell marked, and determine whether a win for max_player or draw and return these tuples of minimax value and cell number in a list.
   end
 
   def possible_moves(current_board, max_player) do
@@ -52,7 +59,7 @@ defmodule TicTacToe.Minimax do
     Enum.find(Enum.zip(current_board, marked_board), fn({x, y}) ->
       x != y
     end)
-  |> elem(0)
+    |> elem(0)
   end
     
 end

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -1,15 +1,32 @@
 defmodule TicTacToe.Minimax do
 
-  def best_move(current_board, {max_player, min_player}) do
-    elem(minimax(current_board, {max_player, min_player}), 1)
+  def best_move(current_board, {player_1, player_2}) do
+    minimax(current_board, 0, {player_1, player_2}, true, 100)
   end
 
-  def minimax(current_board, {max_player, min_player}) do
+  def minimax(current_board, depth, {player_1, player_2}, maximising_player, best_value) do
     cond do
-      terminal?(find_values(current_board, max_player)) ->
-        give_terminal_value(find_values(current_board, max_player))
+      terminal?(find_values(current_board, player_1)) ->
+        give_terminal_value(find_values(current_board, player_1))
+      maximising_player ->
+        val = Enum.map(possible_moves(current_board, player_1), fn(possible_move) ->
+          minimax(possible_move, depth - 1, {player_2, player_1}, false, -best_value)
+        end)
+      |> Enum.max
+      max(best_value, elem(val, 0))
+      :else ->
+        val = Enum.map(possible_moves(current_board, player_1), fn(possible_move) ->
+          minimax(possible_move, depth - 1, {player_1, player_2}, true, best_value)
+        end)
+      |> Enum.max
+      # |> negate
+      min(best_value, elem(val, 0))
     end
   end
+
+  # def negate({score, cell}) do
+  #   {-score, cell}
+  # end
 
   def terminal?(minimax_values) do
     Enum.count(minimax_values) == 1 or Enum.any?(minimax_values, fn({value, _}) ->
@@ -18,15 +35,11 @@ defmodule TicTacToe.Minimax do
   end
 
   def give_terminal_value(minimax_values) do
-    if Enum.count(minimax_values) == 1 do
-      Enum.at(minimax_values, 0)
-    else
-      Enum.max(minimax_values)
-    end
+    Enum.max(minimax_values)
   end
 
-  def find_values(current_board, max_player) do
-    Enum.map(possible_moves(current_board, max_player), fn(possible_board) ->
+  def find_values(current_board, player_1) do
+    Enum.map(possible_moves(current_board, player_1), fn(possible_board) ->
       if TicTacToe.Board.win?(possible_board) do
         {1, changed_cell(current_board, possible_board)} 
       else
@@ -35,9 +48,9 @@ defmodule TicTacToe.Minimax do
     end)
   end
 
-  def possible_moves(current_board, max_player) do
+  def possible_moves(current_board, player_1) do
     Enum.map(available_cells(current_board), fn(cell_to_mark) ->
-      ghost_mark(cell_to_mark, max_player.marker, current_board)
+      ghost_mark(cell_to_mark, player_1.marker, current_board)
     end)
   end
 
@@ -61,5 +74,5 @@ defmodule TicTacToe.Minimax do
     end)
     |> elem(0)
   end
-    
+
 end

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -1,59 +1,28 @@
 defmodule TicTacToe.Minimax do
 
-  def best_move(current_board, {player_1, player_2}) do
-    minimax(current_board, 0, {player_1, player_2}, true, 100)
+  def best_move(current_board) do
+    minimax(current_board)
   end
 
-  def minimax(current_board, depth, {player_1, player_2}, maximising_player, best_value) do
+  def minimax(current_board) do
     cond do
-      terminal?(find_values(current_board, player_1)) ->
-        give_terminal_value(find_values(current_board, player_1))
-      maximising_player ->
-        val = Enum.map(possible_moves(current_board, player_1), fn(possible_move) ->
-          minimax(possible_move, depth - 1, {player_2, player_1}, false, -best_value)
-        end)
-      |> Enum.max
-      max(best_value, elem(val, 0))
-      :else ->
-        val = Enum.map(possible_moves(current_board, player_1), fn(possible_move) ->
-          minimax(possible_move, depth - 1, {player_1, player_2}, true, best_value)
-        end)
-      |> Enum.max
-      # |> negate
-      min(best_value, elem(val, 0))
+      terminal?(current_board) ->
+        terminal_cell(current_board)
     end
   end
 
-  # def negate({score, cell}) do
-  #   {-score, cell}
-  # end
-
-  def terminal?(minimax_values) do
-    Enum.count(minimax_values) == 1 or Enum.any?(minimax_values, fn({value, _}) ->
-      value == 1
-    end)
+  def terminal?(current_board) do
+    current_board
+    |> available_cells
+    |> Enum.count == 1
   end
 
-  def give_terminal_value(minimax_values) do
-    Enum.max(minimax_values)
+  def terminal_cell(current_board) do
+    current_board
+    |> available_cells
+    |> Enum.max
   end
-
-  def find_values(current_board, player_1) do
-    Enum.map(possible_moves(current_board, player_1), fn(possible_board) ->
-      if TicTacToe.Board.win?(possible_board) do
-        {1, changed_cell(current_board, possible_board)} 
-      else
-        {0, changed_cell(current_board, possible_board)} 
-      end
-    end)
-  end
-
-  def possible_moves(current_board, player_1) do
-    Enum.map(available_cells(current_board), fn(cell_to_mark) ->
-      ghost_mark(cell_to_mark, player_1.marker, current_board)
-    end)
-  end
-
+    
   def available_cells(current_board) do
     Enum.filter(current_board, fn(cell) ->
       unmarked?(cell)
@@ -62,17 +31,6 @@ defmodule TicTacToe.Minimax do
 
   def unmarked?(cell) do
     String.match?(cell, ~r/^[1-9]$/)
-  end
-
-  def ghost_mark(cell, marker, current_board) do
-    List.replace_at(current_board, String.to_integer(cell) - 1, marker)
-  end
-
-  def changed_cell(current_board, marked_board) do
-    Enum.find(Enum.zip(current_board, marked_board), fn({x, y}) ->
-      x != y
-    end)
-    |> elem(0)
   end
 
 end

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -1,35 +1,67 @@
 defmodule TicTacToe.Minimax do
 
   def best_move(current_board, current_marker) do
-    minimax(current_board, current_marker)
+    Enum.map(available_cells(current_board), fn(cell) ->
+      possible_board = ghost_mark(cell, current_marker, current_board)
+      score = minimax(possible_board, opponent(current_marker), false)
+      {score, cell}
+    end) |> Enum.max |> elem(1)
   end
 
-  def minimax(current_board, current_marker) do
+  def minimax(current_board, current_marker, maximising_player) do
     cond do
-      terminal?(current_board, current_marker) ->
-        terminal_cell(current_board, current_marker)
+      terminal?(current_board) ->
+        score(current_board, maximising_player)
+      maximising_player ->
+        Enum.map(possible_boards(current_board, current_marker), fn(possible_board) ->
+          minimax(possible_board, opponent(current_marker), !maximising_player)
+        end)
+      |> Enum.max
+      :else ->
+        Enum.map(possible_boards(current_board, current_marker), fn(possible_board) ->
+          minimax(possible_board, opponent(current_marker), !maximising_player)
+        end)
+      |> Enum.min
     end
   end
 
-  def terminal?(current_board, current_marker) do
-    terminal_draw(current_board) or terminal_win(current_board, current_marker)
+  def opponent("x"), do: "o"
+  def opponent("o"), do: "x"
+
+  def terminal?(current_board) do
+    terminal_draw(current_board) or terminal_win(current_board)
   end
 
   def terminal_draw(current_board) do
-    current_board
-    |> available_cells
-    |> Enum.count == 1
+    TicTacToe.Board.draw?(current_board)
   end
 
-  def terminal_win(current_board, current_marker) do
-    Enum.any?(values(current_board, current_marker), fn({value, cell}) ->
-      value == 1
-    end)
+  def terminal_win(current_board) do
+    TicTacToe.Board.win?(current_board)
+  end
+
+  def terminal_cell(current_board, current_marker) do
+    current_board
+    |> possible_boards(current_marker)
+    |> evaluate(current_board)
+    |> Enum.max
+    |> elem(1)
   end
 
   def values(current_board, current_marker) do
     possible_boards(current_board, current_marker)
     |> evaluate(current_board)
+  end
+
+  def score(board, maximising_player) do
+    cond do
+      TicTacToe.Board.win?(board) and maximising_player ->
+        -1
+      TicTacToe.Board.win?(board) and !maximising_player ->
+        1
+      :else ->
+        0
+    end
   end
 
   def evaluate(possible_boards, current_board) do
@@ -60,14 +92,6 @@ defmodule TicTacToe.Minimax do
     List.replace_at(current_board, String.to_integer(cell) - 1, current_marker)
   end
 
-  def terminal_cell(current_board, current_marker) do
-    current_board
-    |> possible_boards(current_marker)
-    |> evaluate(current_board)
-    |> Enum.max
-    |> elem(1)
-  end
-    
   def available_cells(current_board) do
     Enum.filter(current_board, fn(cell) ->
       unmarked?(cell)

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -1,89 +1,51 @@
 defmodule TicTacToe.Minimax do
 
-  def best_move(current_board, {player_1, player_2}) do
-    result1 = minimax(current_board, {player_1, player_2})
-    result2 = minimax(current_board, {player_2, player_1})
+  def best_move(current_board, {max_player, min_player}) do
+    elem(minimax(current_board, [], {max_player, min_player}), 1)
+  end
+
+  def minimax(current_board, minimax_values, {max_player, min_player}) do
     cond do
-      last_turn?(current_board) ->
-        place_last_marker(current_board)
-      Enum.member?(result1, "one") ->
-        return_cell_number(minimax(current_board, {player_1, player_2}), "one")
-      Enum.member?(result2, "one") ->
-      return_cell_number(minimax(current_board, {player_2, player_1}), "one")
-      :else ->
-        possibilities = Enum.map(return_possible_moves(current_board, player_1.marker), fn(possible_move) ->
-          best_move(possible_move, {player_2, player_1})
-        end)
-        Enum.find(possibilities, fn(x) -> is_binary(x) end)
+      terminal?(find_values(current_board, max_player)) ->
+        {0, "3"}
     end
   end
 
-  def place_last_marker(current_board) do
-    Enum.find(current_board, fn(x) ->
-      String.match?(x, ~r/^[1-9]$/)
+  def terminal?(minimax_values) do
+    Enum.count(minimax_values) == 1 or Enum.any?(minimax_values, fn({value, cell_number}) ->
+      value == 1
     end)
   end
 
-  def last_turn?(current_board) do
-    Enum.partition(current_board, fn(x) ->
-      String.match?(x, ~r/^[1-9]$/)
+  def find_values(current_board, max_player) do
+    Enum.map(possible_moves(current_board, max_player), fn(possible_board) ->
+      if TicTacToe.Board.win?(possible_board) do
+        {1, "1"}
+      else
+        {0, "3"}
+      end
     end)
-    |> elem(0)
-    |> Enum.count == 1
+    # for every available cell on the board return a new board with that cell marked, and determine whether a win for max_player or draw and return these tuples of minimax value and cell number in a list.
   end
 
-  def minimax(current_board, {player_1, _player_2}) do 
-    return_possible_moves(current_board, player_1.marker)
-    |> mark_minimax_values(current_board)
-  end
-
-  def return_possible_moves(current_board, marker) do
-    return_possible_moves([], current_board, current_board, marker)
-  end
-
-  def return_possible_moves(possible_boards, [], _board, _marker), do: possible_boards
-  def return_possible_moves(possible_boards, [head | tail], current_board, marker) do
-    if unmarked?(head) do
-      List.insert_at(possible_boards, -1, ghost_mark(head, marker, current_board))
-      |> return_possible_moves(tail, current_board, marker)
-    else
-      return_possible_moves(possible_boards, tail, current_board, marker)
-    end
-  end
-
-  defp mark_minimax_values([], current_board), do: current_board
-  defp mark_minimax_values([head | tail], current_board) do
-      case TicTacToe.Board.win?(head) do
-      true ->
-          mark_minimax_values(tail, List.replace_at(current_board, first_free_cell_index(current_board), "one"))
-      false ->
-        mark_minimax_values(tail, List.replace_at(current_board, first_free_cell_index(current_board), "zero"))
-    end
-  end
-
-  defp first_free_cell_index(current_board) do
-    Enum.find_index(current_board, fn(x) ->
-      String.match?(x, ~r/^[1-9]$/)
+  def possible_moves(current_board, max_player) do
+    Enum.map(available_cells(current_board), fn(cell_to_mark) ->
+      ghost_mark(cell_to_mark, max_player.marker, current_board)
     end)
   end
 
-  defp unmarked?(cell) do
+  def available_cells(current_board) do
+    Enum.filter(current_board, fn(cell) ->
+      unmarked?(cell)
+    end)
+  end
+
+  def unmarked?(cell) do
     String.match?(cell, ~r/^[1-9]$/)
   end
 
-  defp ghost_mark(cell, marker, current_board) do
-    List.replace_at(current_board, get_index(current_board, cell), marker) 
+  def ghost_mark(cell, marker, current_board) do
+    List.replace_at(current_board, String.to_integer(cell) - 1, marker)
   end
-
-  defp get_index(current_board, cell_contents) do
-    Enum.find_index(current_board, fn(x) ->
-      x == cell_contents
-    end)
-  end
-
-  defp return_cell_number(current_board, win_or_lose) do
-    Enum.find_index(current_board, fn(x) -> x == win_or_lose end) + 1
-    |> Integer.to_string
-  end
-
+    
 end

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -1,26 +1,64 @@
 defmodule TicTacToe.Minimax do
 
-  def best_move(current_board) do
-    minimax(current_board)
+  def best_move(current_board, current_marker) do
+    minimax(current_board, current_marker)
   end
 
-  def minimax(current_board) do
+  def minimax(current_board, current_marker) do
     cond do
-      terminal?(current_board) ->
-        terminal_cell(current_board)
+      terminal?(current_board, current_marker) ->
+        terminal_cell(current_board, current_marker)
     end
   end
 
-  def terminal?(current_board) do
+  def terminal?(current_board, current_marker) do
+    terminal_draw(current_board) or terminal_win(current_board, current_marker)
+  end
+
+  def terminal_draw(current_board) do
     current_board
     |> available_cells
     |> Enum.count == 1
   end
 
-  def terminal_cell(current_board) do
+  def terminal_win(current_board, current_marker) do
+    values(possible_boards(current_board, current_marker), current_board)
+  end
+
+  def values(possible_boards, current_board) do
+    Enum.map(possible_boards, fn(possible_board) ->
+      if TicTacToe.Board.win?(possible_board) do
+        {1, changed_cell(current_board, possible_board)}
+      else
+        {0, changed_cell(current_board, possible_board)}
+      end
+    end)
+  end
+
+  def possible_boards(current_board, current_marker) do
+    Enum.map(available_cells(current_board), fn(cell) ->
+      ghost_mark(cell, current_marker, current_board)
+    end)
+  end
+
+  def changed_cell(current_board, possible_board) do
+    comparisons = Enum.zip(current_board, possible_board)
+    Enum.find(comparisons, fn({current_cell, possible_cell}) ->
+      current_cell != possible_cell
+    end)
+    |> elem(0)
+  end
+
+  def ghost_mark(cell, current_marker, current_board) do
+    List.replace_at(current_board, String.to_integer(cell) - 1, current_marker)
+  end
+
+  def terminal_cell(current_board, current_marker) do
     current_board
-    |> available_cells
+    |> possible_boards(current_marker)
+    |> values(current_board)
     |> Enum.max
+    |> elem(1)
   end
     
   def available_cells(current_board) do

--- a/lib/minimax.ex
+++ b/lib/minimax.ex
@@ -22,10 +22,17 @@ defmodule TicTacToe.Minimax do
   end
 
   def terminal_win(current_board, current_marker) do
-    values(possible_boards(current_board, current_marker), current_board)
+    Enum.any?(values(current_board, current_marker), fn({value, cell}) ->
+      value == 1
+    end)
   end
 
-  def values(possible_boards, current_board) do
+  def values(current_board, current_marker) do
+    possible_boards(current_board, current_marker)
+    |> evaluate(current_board)
+  end
+
+  def evaluate(possible_boards, current_board) do
     Enum.map(possible_boards, fn(possible_board) ->
       if TicTacToe.Board.win?(possible_board) do
         {1, changed_cell(current_board, possible_board)}
@@ -56,7 +63,7 @@ defmodule TicTacToe.Minimax do
   def terminal_cell(current_board, current_marker) do
     current_board
     |> possible_boards(current_marker)
-    |> values(current_board)
+    |> evaluate(current_board)
     |> Enum.max
     |> elem(1)
   end

--- a/test/game_test.exs
+++ b/test/game_test.exs
@@ -55,12 +55,6 @@ defmodule TicTacToeTest.Game do
     end) =~ "Welcome to Tic Tac Toe"
   end
 
-  test "a computer vs computer game plays" do
-    assert capture_io("d\nI'm done", fn -> 
-      TicTacToe.Game.play_tic_tac_toe
-    end) =~ "Computer 1's turn"
-  end
-
   test "shows score when one game ends" do
     assert capture_io("a\nGary\nBarry\n1\n2\n5\n4\n9\nI'm done", fn ->
       TicTacToe.Game.play_tic_tac_toe

--- a/test/messager_test.exs
+++ b/test/messager_test.exs
@@ -29,7 +29,7 @@ defmodule TicTacToeTest.Messager do
   end
 
   test "returns request for turn" do
-    assert TicTacToe.Messager.turn_input_request("Gary", "x") =~ "Gary's turn with the marker x"
+    assert TicTacToe.Messager.turn_input_request("Gary", "x") =~ "Gary's turn"
   end
 
   test "returns message for unavailable cell" do

--- a/test/minimax_test.exs
+++ b/test/minimax_test.exs
@@ -22,7 +22,7 @@ defmodule TicTacToeTest.Minimax do
                      "4", "x", "6",
                      "o", "8", "x"]
     possible_boards = TicTacToe.Minimax.possible_boards(current_board, "x")
-    assert TicTacToe.Minimax.values(possible_boards, current_board) == [{1, "1"}, {0, "3"}, {0, "4"}, {0, "6"}, {0, "8"}]
+    assert TicTacToe.Minimax.evaluate(possible_boards, current_board) == [{1, "1"}, {0, "3"}, {0, "4"}, {0, "6"}, {0, "8"}]
   end
 
   test "returns best move when terminal due to win" do
@@ -35,5 +35,12 @@ defmodule TicTacToeTest.Minimax do
                       "o", "8", "x"]
     assert TicTacToe.Minimax.best_move(current_board, "x") == "1"
   end
+
+  # test "returns best move for blocking win of opponent" do
+  #   current_board =   ["1", "2", "3",
+  #                     "4", "x", "o",
+  #                     "o", "8", "x"]
+  #   assert TicTacToe.Minimax.best_move(current_board, "o") == "1"
+  # end
 
 end

--- a/test/minimax_test.exs
+++ b/test/minimax_test.exs
@@ -14,6 +14,11 @@ defmodule TicTacToeTest.Minimax do
                      "o", "x", "o"]
     max_player = TicTacToe.HumanPlayer.build("Computer", "o")
     assert TicTacToe.Minimax.find_values(current_board, max_player) == [{1, "1"}, {0, "3"}]
+    current_board = ["1", "o", "3",
+                     "o", "5", "x",
+                     "o", "x", "o"]
+    max_player = TicTacToe.HumanPlayer.build("Computer", "o")
+    assert TicTacToe.Minimax.find_values(current_board, max_player) == [{1, "1"}, {0, "3"}, {0, "5"}]
   end
 
   # test "computer marks only remaining available space" do

--- a/test/minimax_test.exs
+++ b/test/minimax_test.exs
@@ -1,16 +1,64 @@
 defmodule TicTacToeTest.Minimax do
   use ExUnit.Case
 
-  test "returns terminal move when only option" do
-    current_board =  ["x", "o", "3",
-                      "o", "x", "x",
-                      "o", "x", "o"]
-    assert TicTacToe.Minimax.best_move(current_board, "x") == "3"
-    current_board =  ["1", "o", "x",
-                      "o", "x", "x",
-                      "o", "x", "o"]
-    assert TicTacToe.Minimax.best_move(current_board, "x") == "1"
+  test "scores win as 1" do
+    current_board =  ["1", "2", "x",
+                      "o", "x", "6",
+                      "x", "o", "9"]
+
+    assert TicTacToe.Minimax.minimax(current_board, "o", true) == -1
+    assert TicTacToe.Minimax.minimax(current_board, "o", false) == 1
   end
+
+  test "scores draw as 0" do
+    current_board =  ["x", "x", "o",
+                      "o", "o", "x",
+                      "x", "x", "o"]
+
+    assert TicTacToe.Minimax.minimax(current_board, "x", true) == 0
+    assert TicTacToe.Minimax.minimax(current_board, "x", false) == 0
+  end
+
+  test "scores possible win as a 1" do
+    current_board =  ["1", "o", "o",
+                      "x", "x", "o",
+                      "x", "o", "x"]
+
+    assert TicTacToe.Minimax.minimax(current_board, "x", true) == 1
+    assert TicTacToe.Minimax.minimax(current_board, "x", false) == -1
+  end
+
+  test "scores possible win two moves down as a 2" do
+    current_board =  ["1", "o", "3",
+                      "4", "x", "o",
+                      "7", "x", "9"]
+
+    assert TicTacToe.Minimax.minimax(current_board, "x", true) == 1
+    assert TicTacToe.Minimax.minimax(current_board, "x", false) == -1
+  end
+
+  test "scores an unwinnable board as 0" do
+    current_board =  ["o", "2", "3",
+                      "x", "x", "o",
+                      "o", "8", "x"]
+
+    assert TicTacToe.Minimax.minimax(current_board, "x", true) == 0
+    assert TicTacToe.Minimax.minimax(current_board, "x", false) == 0
+  end
+
+  test "scores empty board as 0" do
+    current_board =  ["1", "2", "3",
+                      "4", "5", "6",
+                      "7", "8", "9"]
+
+    assert TicTacToe.Minimax.minimax(current_board, "x", true) == 0
+  end
+
+
+
+
+
+
 
   test "gives possible_boards" do
     current_board = ["1", "o", "3"]
@@ -25,22 +73,39 @@ defmodule TicTacToeTest.Minimax do
     assert TicTacToe.Minimax.evaluate(possible_boards, current_board) == [{1, "1"}, {0, "3"}, {0, "4"}, {0, "6"}, {0, "8"}]
   end
 
+  test "winning board is terminal" do
+    current_board = ["x", "o", "3",
+                     "4", "x", "6",
+                     "o", "8", "x"]
+    assert TicTacToe.Minimax.terminal?(current_board)
+  end
+
+  test "inplay board is not terminal" do
+    current_board = ["1", "o", "3",
+                     "4", "x", "6",
+                     "o", "9", "x"]
+    refute TicTacToe.Minimax.terminal?(current_board)
+  end
+
   test "returns best move when terminal due to win" do
     current_board =   ["x", "o", "3",
                       "4", "x", "6",
                       "o", "8", "9"]
     assert TicTacToe.Minimax.best_move(current_board, "x") == "9"
     current_board =   ["1", "o", "3",
-                      "4", "x", "6",
+                      "4", "x", "o",
                       "o", "8", "x"]
     assert TicTacToe.Minimax.best_move(current_board, "x") == "1"
   end
 
-  # test "returns best move for blocking win of opponent" do
-  #   current_board =   ["1", "2", "3",
-  #                     "4", "x", "o",
-  #                     "o", "8", "x"]
-  #   assert TicTacToe.Minimax.best_move(current_board, "o") == "1"
-  # end
-
+  test "returns best move for blocking win of opponent" do
+    current_board =   ["1", "2", "3",
+                      "4", "x", "o",
+                      "o", "8", "x"]
+    assert TicTacToe.Minimax.best_move(current_board, "o") == "1"
+    current_board =   ["1", "2", "3",
+                      "4", "x", "o",
+                      "x", "o", "9"]
+    assert TicTacToe.Minimax.best_move(current_board, "o") == "3"
+  end
 end

--- a/test/minimax_test.exs
+++ b/test/minimax_test.exs
@@ -2,10 +2,18 @@ defmodule TicTacToeTest.Minimax do
   use ExUnit.Case
 
   test "returns list of available cells for possible_moves" do
-    current_board = ["x", "o", "3",
+    current_board =  ["x", "o", "3",
+                      "o", "x", "x",
+                      "o", "x", "o"]
+    assert TicTacToe.Minimax.available_cells(current_board) == ["3"]
+  end
+
+  test "returns list of possible moves" do
+    current_board = ["1", "o", "3",
                      "o", "x", "x",
                      "o", "x", "o"]
-    assert TicTacToe.Minimax.available_cells(current_board) == ["3"]
+    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
+    assert TicTacToe.Minimax.possible_moves(current_board, player_1) == [["o", "o", "3", "o", "x", "x", "o", "x", "o"], ["1", "o", "o", "o", "x", "x", "o", "x", "o"]]
   end
 
   test "returns minimax value and cell for every possible move" do
@@ -46,6 +54,60 @@ defmodule TicTacToeTest.Minimax do
     player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
     player_2 = TicTacToe.HumanPlayer.build("gary", "x")
     assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "3"
+  end
+
+  test "minimax returns favourable value" do
+    current_board = ["1", "o", "3",
+                     "4", "x", "x",
+                     "o", "x", "o"]
+    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
+    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
+    assert TicTacToe.Minimax.minimax(current_board, 0, {player_1, player_2}, true, 100) == {1, "4"}
+  end
+
+  test "computer blocks opponent" do
+    current_board = ["1", "o", "3",
+                     "4", "x", "x",
+                     "o", "x", "o"]
+    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
+    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
+    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "4"
+  end
+
+  test "computer blocks opponent another way" do
+    current_board = ["1", "x", "3",
+                     "4", "5", "6",
+                     "x", "o", "9"]
+    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
+    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
+    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "1" || "3" || "4"
+  end
+
+  test "computer blocks opponent cross move" do
+    current_board = ["1", "2", "3",
+                     "4", "5", "6",
+                     "x", "8", "9"]
+    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
+    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
+    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "5" || "3"
+  end
+
+  test "computer blocks opponent win" do
+    current_board = ["1", "x", "o",
+                     "x", "o", "6",
+                     "x", "8", "9"]
+    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
+    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
+    assert TicTacToe.Minimax.best_move(current_board,  {player_1, player_2}) == "1"
+  end
+
+  test "computer blocks future opponent win" do
+    current_board = ["1", "o", "3",
+                     "4", "x", "6",
+                     "o", "x", "9"]
+    player_1 = TicTacToe.HumanPlayer.build("Computer", "x")
+    player_2 = TicTacToe.HumanPlayer.build("gary", "o")
+    assert TicTacToe.Minimax.best_move(current_board,  {player_1, player_2}) == "1" || "4" || "3"
   end
 
 end

--- a/test/minimax_test.exs
+++ b/test/minimax_test.exs
@@ -1,90 +1,28 @@
 defmodule TicTacToeTest.Minimax do
   use ExUnit.Case
 
-  test "minimax values are determined" do
-    current_board = ["o", "2", "x", "x", "x", "o", "7", "8", "o"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "x")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "o")
-    assert TicTacToe.Minimax.minimax(current_board, {player_1, player_2}) == ["o", "zero", "x", "x", "x", "o", "one", "zero", "o"]
-  end
-
-  test "current player returns possible moves for next turn on one board for each move" do
-    current_board = ["x", "o", "o", "o", "x", "6", "7", "8", "9"]
-    assert TicTacToe.Minimax.return_possible_moves(current_board, "x") == [
-      ["x", "o", "o", "o", "x", "x", "7", "8", "9"],
-      ["x", "o", "o", "o", "x", "6", "x", "8", "9"],
-      ["x", "o", "o", "o", "x", "6", "7", "x", "9"],
-      ["x", "o", "o", "o", "x", "6", "7", "8", "x"]]
-  end
-
-  test "current player chooses to win" do
-    current_board = ["x", "o", "o",
-                     "o", "x", "6",
-                     "7", "8", "9"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "x")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "o")
-    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "9"
-  end
-
-  test "current player chooses to block" do
-    current_board = ["x", "o", "o",
-                     "4", "x", "6",
-                     "7", "8", "9"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "9"
-  end
-
-  test "current player blocks future opponent win" do
-    current_board = ["x", "2", "3",
-                     "4", "o", "6",
-                     "7", "8", "x"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert Enum.member?(["2", "3", "4", "6", "7", "8"], TicTacToe.Minimax.best_move(current_board, {player_1, player_2}))
-  end
-
-  test "blocks another fork attempt" do
-    current_board = ["x", "2", "3",
-                     "4", "x", "6",
-                     "7", "8", "o"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert Enum.member?(["3", "7"], TicTacToe.Minimax.best_move(current_board, {player_1, player_2}))
-  end
-
-  test "blocks another alternative fork attempt" do
-    current_board = ["1", "2", "3",
-                     "4", "5", "x",
-                     "7", "x", "o"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert Enum.member?(["5", "4", "2"], TicTacToe.Minimax.best_move(current_board, {player_1, player_2}))
-  end
-
-  test "blocks player while also trying to win" do
-    current_board = ["x", "2", "3",
-                     "o", "5", "x",
-                     "o", "x", "o"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert Enum.member?(["5", "2"], TicTacToe.Minimax.best_move(current_board, {player_1, player_2}))
-  end
-
-  test "computer ends game with a draw" do
+  test "returns list of available cells for possible_moves" do
     current_board = ["x", "o", "3",
                      "o", "x", "x",
                      "o", "x", "o"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "3"
+    assert TicTacToe.Minimax.available_cells(current_board) == ["3"]
   end
 
-  test "knows when last turn" do
-    current_board = ["x", "o", "3",
+  test "returns minimax value and cell for every possible move" do
+    current_board = ["1", "o", "3",
                      "o", "x", "x",
                      "o", "x", "o"]
-    assert TicTacToe.Minimax.last_turn?(current_board) == true 
+    max_player = TicTacToe.HumanPlayer.build("Computer", "o")
+    assert TicTacToe.Minimax.find_values(current_board, max_player) == [{1, "1"}, {0, "3"}]
   end
+
+  # test "computer marks only remaining available space" do
+  #   current_board = ["x", "o", "3",
+  #                    "o", "x", "x",
+  #                    "o", "x", "o"]
+  #   player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
+  #   player_2 = TicTacToe.HumanPlayer.build("gary", "x")
+  #   assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "3"
+  # end
 
 end

--- a/test/minimax_test.exs
+++ b/test/minimax_test.exs
@@ -21,13 +21,31 @@ defmodule TicTacToeTest.Minimax do
     assert TicTacToe.Minimax.find_values(current_board, max_player) == [{1, "1"}, {0, "3"}, {0, "5"}]
   end
 
-  # test "computer marks only remaining available space" do
-  #   current_board = ["x", "o", "3",
-  #                    "o", "x", "x",
-  #                    "o", "x", "o"]
-  #   player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-  #   player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-  #   assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "3"
-  # end
+  test "gives a draw terminal value" do
+    current_board = ["x", "o", "3",
+                     "o", "x", "x",
+                     "o", "x", "o"]
+    max_player = TicTacToe.HumanPlayer.build("Computer", "o")
+    values = TicTacToe.Minimax.find_values(current_board, max_player)
+    assert TicTacToe.Minimax.give_terminal_value(values) == {0, "3"}
+  end
+
+  test "gives a win terminal value" do
+    current_board = ["x", "o", "o",
+                     "4", "5", "x",
+                     "o", "8", "x"]
+    max_player = TicTacToe.HumanPlayer.build("Computer", "o")
+    values = TicTacToe.Minimax.find_values(current_board, max_player)
+    assert TicTacToe.Minimax.give_terminal_value(values) == {1, "5"}
+  end
+
+  test "computer marks only remaining available space" do
+    current_board = ["x", "o", "3",
+                     "o", "x", "x",
+                     "o", "x", "o"]
+    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
+    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
+    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "3"
+  end
 
 end

--- a/test/minimax_test.exs
+++ b/test/minimax_test.exs
@@ -1,113 +1,15 @@
 defmodule TicTacToeTest.Minimax do
   use ExUnit.Case
 
-  test "returns list of available cells for possible_moves" do
+  test "returns best move for terminal move when only option" do
     current_board =  ["x", "o", "3",
                       "o", "x", "x",
                       "o", "x", "o"]
-    assert TicTacToe.Minimax.available_cells(current_board) == ["3"]
-  end
-
-  test "returns list of possible moves" do
-    current_board = ["1", "o", "3",
-                     "o", "x", "x",
-                     "o", "x", "o"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    assert TicTacToe.Minimax.possible_moves(current_board, player_1) == [["o", "o", "3", "o", "x", "x", "o", "x", "o"], ["1", "o", "o", "o", "x", "x", "o", "x", "o"]]
-  end
-
-  test "returns minimax value and cell for every possible move" do
-    current_board = ["1", "o", "3",
-                     "o", "x", "x",
-                     "o", "x", "o"]
-    max_player = TicTacToe.HumanPlayer.build("Computer", "o")
-    assert TicTacToe.Minimax.find_values(current_board, max_player) == [{1, "1"}, {0, "3"}]
-    current_board = ["1", "o", "3",
-                     "o", "5", "x",
-                     "o", "x", "o"]
-    max_player = TicTacToe.HumanPlayer.build("Computer", "o")
-    assert TicTacToe.Minimax.find_values(current_board, max_player) == [{1, "1"}, {0, "3"}, {0, "5"}]
-  end
-
-  test "gives a draw terminal value" do
-    current_board = ["x", "o", "3",
-                     "o", "x", "x",
-                     "o", "x", "o"]
-    max_player = TicTacToe.HumanPlayer.build("Computer", "o")
-    values = TicTacToe.Minimax.find_values(current_board, max_player)
-    assert TicTacToe.Minimax.give_terminal_value(values) == {0, "3"}
-  end
-
-  test "gives a win terminal value" do
-    current_board = ["x", "o", "o",
-                     "4", "5", "x",
-                     "o", "8", "x"]
-    max_player = TicTacToe.HumanPlayer.build("Computer", "o")
-    values = TicTacToe.Minimax.find_values(current_board, max_player)
-    assert TicTacToe.Minimax.give_terminal_value(values) == {1, "5"}
-  end
-
-  test "computer marks only remaining available space" do
-    current_board = ["x", "o", "3",
-                     "o", "x", "x",
-                     "o", "x", "o"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "3"
-  end
-
-  test "minimax returns favourable value" do
-    current_board = ["1", "o", "3",
-                     "4", "x", "x",
-                     "o", "x", "o"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert TicTacToe.Minimax.minimax(current_board, 0, {player_1, player_2}, true, 100) == {1, "4"}
-  end
-
-  test "computer blocks opponent" do
-    current_board = ["1", "o", "3",
-                     "4", "x", "x",
-                     "o", "x", "o"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "4"
-  end
-
-  test "computer blocks opponent another way" do
-    current_board = ["1", "x", "3",
-                     "4", "5", "6",
-                     "x", "o", "9"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "1" || "3" || "4"
-  end
-
-  test "computer blocks opponent cross move" do
-    current_board = ["1", "2", "3",
-                     "4", "5", "6",
-                     "x", "8", "9"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert TicTacToe.Minimax.best_move(current_board, {player_1, player_2}) == "5" || "3"
-  end
-
-  test "computer blocks opponent win" do
-    current_board = ["1", "x", "o",
-                     "x", "o", "6",
-                     "x", "8", "9"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "o")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "x")
-    assert TicTacToe.Minimax.best_move(current_board,  {player_1, player_2}) == "1"
-  end
-
-  test "computer blocks future opponent win" do
-    current_board = ["1", "o", "3",
-                     "4", "x", "6",
-                     "o", "x", "9"]
-    player_1 = TicTacToe.HumanPlayer.build("Computer", "x")
-    player_2 = TicTacToe.HumanPlayer.build("gary", "o")
-    assert TicTacToe.Minimax.best_move(current_board,  {player_1, player_2}) == "1" || "4" || "3"
+    assert TicTacToe.Minimax.best_move(current_board) == "3"
+    current_board =  ["1", "o", "x",
+                      "o", "x", "x",
+                      "o", "x", "o"]
+    assert TicTacToe.Minimax.best_move(current_board) == "1"
   end
 
 end


### PR DESCRIPTION
I rewrote the minimax module (several times!). The best move function only takes the current board and the current player's marker as arguments.

Therefore the ComputerPlayer move function now takes the same arguments.

The minimax function depends on taking a single "x" or "o", so ANSI colour codes could not be included in the marker struct.
This meant I had to:
   - remove ANSI colour codes where they are used in building players in the Game module.
   - use ANSI colour codes instead in the Messager module, which makes much more sense as they are related to the display here.

In the Messager module I created a colour_marker function which colours the individual marker which is passed into Messager functions, and a colour_board function which uses colour_marker to change markers to their correct colouring on the board as they are passed in.

I changed Messager tests where they were disrupted by these ANSI colour codes to instead concentrate on including parts of the message output that show the correct message function has been called.

I removed the computer vs computer test from game as the correct outcome is tested in the minimax tests (i.e. computer vs computer always draws).



